### PR TITLE
Fix parsing and command handling bugs

### DIFF
--- a/remote/SonanceClient.py
+++ b/remote/SonanceClient.py
@@ -87,7 +87,7 @@ class SonanceResponse:
 
 class SonanceZoneState:
 
-    def __init(self,zone,source,power,volume):
+    def __init__(self, zone=None, source=None, power=None, volume=None):
         self.zone = zone
         self.source = source
         self.power = power
@@ -119,7 +119,7 @@ class SonanceQueryResponse(SonanceResponse):
         #print "query_response->%s<-" % message
 
     def __str__(self):
-        return json.dumps({'qtype': self.qtype, 'status': self._status, 'zone': self.zone, 'value': self.value})
+        return json.dumps({'qtype': self.qtype, 'status': self.status, 'zone': self.zone, 'value': self.value})
 
     def set_zone(self, zone):
         self.zone = zone
@@ -130,12 +130,12 @@ class SonanceQueryResponse(SonanceResponse):
     def get_status(self):
         return self.status
 
-    def value(self):
+    def get_value(self):
         return self.value
 
     def parse(self):
         if self.message[0] != '+':
-            self._status = SONANCE_BAD_MESSAGE
+            self.status = SonanceResponse.SONANCE_BAD_MESSAGE
         elif len(self.message) >= 3:
             self.qtype = self.message[1]
             self.zone = self.message[2]
@@ -159,7 +159,7 @@ class SonanceRemote:
 
     def connect(self, host=os.getenv('SONANCE_SERVER_HOSTNAME', "127.0.0.1"), port=os.getenv('SONANCE_SERVER_PORT', "7777")):
         try:
-            self._s = socket.create_connection((host,port))
+            self._s = socket.create_connection((host, int(port)))
             print "Connected to %s:%s" % (host, port)
             return True
         except socket.error, v:
@@ -179,11 +179,10 @@ class SonanceRemote:
                 break
             else:
                 msg += pkt
-                if msg.endswith('+OK',0,-2):
+                if msg.endswith('+OK',0,-2) or msg.endswith('+ERR',0,-2):
                     lines = msg.splitlines()
-                    return SonanceCommandResponse(lines[0],SonanceResponse.SONANCE_OK)
-                elif msg.endswith('+ERR',0,-2):
-                    return SonanceCommandResponse(lines[0],SonanceResponse.SONANCE_ERROR)
+                    status = SonanceResponse.SONANCE_OK if msg.endswith('+OK',0,-2) else SonanceResponse.SONANCE_ERROR
+                    return SonanceCommandResponse(lines[0], status)
 
     def send_query(self, cmd):
         #print "send_query(%s) = " % cmd
@@ -253,4 +252,7 @@ class SonanceQuery():
         return state
 
     def zoneStates(self):
-        foreach
+        states = []
+        for zone_id in range(1, 7):
+            states.append(self.zoneState(zone_id))
+        return states

--- a/remote/SonanceWeb.py
+++ b/remote/SonanceWeb.py
@@ -51,13 +51,6 @@ def zone_source(zone_id,source_id):
     sonance_remote.disconnect()
     return res.__str__()
 
-@route('/sonance/zones/<zone_id>/source/<source_id>',method='GET')
-def zone_source(zone_id,source_id):
-    sonance_remote.connect()
-    res = SonanceCommand(sonance_remote).source(int(zone_id),int(source_id))
-    sonance_remote.disconnect()
-    return res.__str__()
-
 @route('/sonance/zones/<zone_id>/volume/<volume_level>',method='GET')
 def zone_volume(zone_id,volume_level):
     sonance_remote.connect()


### PR DESCRIPTION
## Summary
- clean up duplicate routes in SonanceWeb
- fix port handling and command parsing in SonanceClient
- repair SonanceZoneState constructor and query parser
- implement `zoneStates` helper

## Testing
- `python3 remote/SonanceClientTests.py` *(fails: SyntaxError: Missing parentheses in call to 'print')*
- `python3 -m py_compile remote/SonanceWeb.py`

------
https://chatgpt.com/codex/tasks/task_e_6860aa49f8648326b8cbe3bbdd5fbf5f