### PR TITLE
Update to Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Provides an HTML5 interface to the Sonance DAB1 (http://www.soundandvision.com/content/sonance-dab1-distributed-audio-system)
 
-* Assumes you have a raspberryip, or something running python 2.7, attached via RS232 serial null modem cable to a Sonance DAB1.
+* Originally targeted Python 2.7 but now updated for Python 3. A Raspberry Pi or similar device attached via RS232 serial null modem cable to a Sonance DAB1 works well.
 
 * Uses the sonance serial port and serial protocol to control the DAB1
 
@@ -10,7 +10,7 @@ Provides an HTML5 interface to the Sonance DAB1 (http://www.soundandvision.com/c
 
 ##Requirements
 
-* Python 2.7
+* Python 3
 * Pyserial 2.7
 
 ##Notes

--- a/remote/SonanceClient.py
+++ b/remote/SonanceClient.py
@@ -8,6 +8,8 @@ import socket
 import json
 import os
 
+# NOTE: Originally written for Python 2.7 and updated for Python 3 compatibility.
+
 class SonanceSource:
     TUNER = 1
     AIRPORT = 2
@@ -49,7 +51,8 @@ class SonanceMessage:
 
     def received(self):
         if self.body.endswith(SonanceMessage.TERMINATOR):
-            print "message received = %s" % self.body
+            # Python 3 print function
+            print("message received = %s" % self.body)
             return True
         return False
 
@@ -160,10 +163,12 @@ class SonanceRemote:
     def connect(self, host=os.getenv('SONANCE_SERVER_HOSTNAME', "127.0.0.1"), port=os.getenv('SONANCE_SERVER_PORT', "7777")):
         try:
             self._s = socket.create_connection((host,port))
-            print "Connected to %s:%s" % (host, port)
+            # Connection successful
+            print("Connected to %s:%s" % (host, port))
             return True
-        except socket.error, v:
-            print "Connection Error..."
+        except socket.error as e:
+            # Socket error from Python 2 syntax updated for Python 3
+            print("Connection Error...")
             return False
 
     def disconnect(self):

--- a/remote/SonanceClientTests.py
+++ b/remote/SonanceClientTests.py
@@ -64,11 +64,12 @@ class TestQueries(unittest.TestCase):
         self.assertTrue(self.query.mute(SonanceZone.OFFICE).get_status())
 
     def test_zone_state(self):
-        print self.query.zoneState(SonanceZone.OFFICE)
-        print self.query.zoneState(SonanceZone.LIVING_ROOM)
-        print self.query.zoneState(SonanceZone.KITCHEN)
-        print self.query.zoneState(SonanceZone.MASTER_BEDROOM)
-        print self.query.zoneState(SonanceZone.AVAS_BEDROOM)
-        print self.query.zoneState(SonanceZone.OUTDOOR)
+        # Debug prints updated for Python 3
+        print(self.query.zoneState(SonanceZone.OFFICE))
+        print(self.query.zoneState(SonanceZone.LIVING_ROOM))
+        print(self.query.zoneState(SonanceZone.KITCHEN))
+        print(self.query.zoneState(SonanceZone.MASTER_BEDROOM))
+        print(self.query.zoneState(SonanceZone.AVAS_BEDROOM))
+        print(self.query.zoneState(SonanceZone.OUTDOOR))
 
 


### PR DESCRIPTION
## Summary
- switch print statements in `remote` to Python 3 style
- modernize socket exception handling
- update README for Python 3 usage

## Testing
- `python3 -m py_compile remote/SonanceClient.py remote/SonanceClientTests.py remote/SonancePlugin.py remote/SonanceWeb.py`

------
https://chatgpt.com/codex/tasks/task_e_6860acdbde5c832698407bb88fe4b545