### PR TITLE
Fix typo, docstring, bug and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Provides an HTML5 interface to the Sonance DAB1 (http://www.soundandvision.com/content/sonance-dab1-distributed-audio-system)
 
-* Assumes you have a raspberryip, or something running python 2.7, attached via RS232 serial null modem cable to a Sonance DAB1.
+* Assumes you have a raspberry pi, or something running python 2.7, attached via RS232 serial null modem cable to a Sonance DAB1.
 
 * Uses the sonance serial port and serial protocol to control the DAB1
 

--- a/remote/SonanceClient.py
+++ b/remote/SonanceClient.py
@@ -183,6 +183,7 @@ class SonanceRemote:
                     lines = msg.splitlines()
                     return SonanceCommandResponse(lines[0],SonanceResponse.SONANCE_OK)
                 elif msg.endswith('+ERR',0,-2):
+                    lines = msg.splitlines()
                     return SonanceCommandResponse(lines[0],SonanceResponse.SONANCE_ERROR)
 
     def send_query(self, cmd):

--- a/remote/SonanceClientTests.py
+++ b/remote/SonanceClientTests.py
@@ -27,7 +27,8 @@ class TestCommands(unittest.TestCase):
 
     def test_volume(self):
         c = SonanceCommand(self.r)
-        self.assertTrue(c.muteoff(SonanceZone.OFFICE).status, SonanceCommandResponse.SONANCE_OK)
+        result = c.volume(SonanceZone.OFFICE, SonanceVolume.NORMAL)
+        self.assertEqual(result.status, SonanceResponse.SONANCE_OK)
 
     def test_muteon(self):
         c = SonanceCommand(self.r)

--- a/remote/SonancePlugin.py
+++ b/remote/SonancePlugin.py
@@ -3,8 +3,8 @@ from SonanceClient import SonanceRemote, SonanceQuery
 import inspect
 
 class SonanceQueryPlugin(object):
-    ''' This plugin passes an SonanceClient handle to route callbacks. You can override the database
-    settings on a per-route basis. '''
+    '''Injects a ``SonanceQuery`` instance into route callbacks so handlers can
+    communicate with the Sonance DAB1.'''
 
     name = 'sonance'
     api = 2


### PR DESCRIPTION
## Summary
- fix raspberry pi typo in README
- handle `+ERR` responses correctly in `send_command`
- clarify docstring in `SonanceQueryPlugin`
- improve the `test_volume` test case

## Testing
- `python -m unittest discover -v` *(found 0 tests)*
- `python -m unittest remote.SonanceClientTests -v` *(failed: SyntaxError due to Python 2 style)*

------
https://chatgpt.com/codex/tasks/task_e_6860aa4a09ec83268ad6b3471556be22